### PR TITLE
Re-export symbols to match PEP 484 standard.

### DIFF
--- a/aws_error_utils/__init__.py
+++ b/aws_error_utils/__init__.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 from .aws_error_utils import (
-    __version__,
-    AWSErrorInfo,
-    get_aws_error_info,
-    ALL_CODES,
-    ALL_OPERATIONS,
-    aws_error_matches,
-    catch_aws_error,
-    BotoCoreError,
-    ClientError,
-    errors,
-    make_aws_error,
+    __version__ as __version__,
+    AWSErrorInfo as AWSErrorInfo,
+    get_aws_error_info as get_aws_error_info,
+    ALL_CODES as ALL_CODES,
+    ALL_OPERATIONS as ALL_OPERATIONS,
+    aws_error_matches as aws_error_matches,
+    catch_aws_error as catch_aws_error,
+    BotoCoreError as BotoCoreError,
+    ClientError as ClientError,
+    errors as errors,
+    make_aws_error as make_aws_error,
 )


### PR DESCRIPTION
Python type checker libraries such as Pyright have built a consensus around PEP 484 for how to export symbols from a py.typed library. This requires redundantly re-exporting symbols to make them publicly visible.

Without re-exporting the symbol type checkers will complain that the symbol  (e.g., from aws_error_utils.errors) is not exported, but a direct import will work as expected (e.g., from aws_error_utils.aws_error_utils import errors).

Based on official Python guidance to type checkers: https://github.com/python/typing/blob/master/docs/source/libraries.rst#library-interface-public-and-private-symbols

For more detail from author of Pyright (for a similar issue in PyTorch): https://github.com/microsoft/pylance-release/issues/2953#issuecomment-1168408943

This should resolve #9.